### PR TITLE
packer-{rocm,maas}: improve "custom-packages" longevity, bump submodule

### DIFF
--- a/.github/workflows/packer-rocm.yaml
+++ b/.github/workflows/packer-rocm.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: ansible-lint
         run: |
-          ansible-lint --profile production --parseable --nocolor packer-rocm/
+          ansible-lint --profile production --parseable --nocolor --exclude packer-rocm/packer-maas/ packer-rocm/
 
 # Not yet validating HCL, challenge:
 # Many out-of-place references to 'packer-maas' until playbook-run; Packer is strict

--- a/.github/workflows/packer-rocm.yaml
+++ b/.github/workflows/packer-rocm.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: ansible-lint
         run: |
-          ansible-lint --profile production --parseable --nocolor --exclude packer-rocm/packer-maas/ packer-rocm/
+          ansible-lint --profile production --parseable --nocolor --exclude='packer-rocm/packer-maas/' packer-rocm/
 
 # Not yet validating HCL, challenge:
 # Many out-of-place references to 'packer-maas' until playbook-run; Packer is strict


### PR DESCRIPTION
Updating the `packer-maas` submodule for `packer-maas`, largely for [this commit](https://github.com/canonical/packer-maas/commit/046b0986c630e71b772c6581d39c72ae89a00647).

Resolves: may find the Apt caches have gone stale when using the `custom-packages` facility