### PR TITLE
Fix remainder of power supply logic typos

### DIFF
--- a/smci_mi325x_platform_amdgpu_alllogs_collection_for_current_bmc_firmware.py
+++ b/smci_mi325x_platform_amdgpu_alllogs_collection_for_current_bmc_firmware.py
@@ -235,7 +235,7 @@ def check_power_supplies(bmc_ip, bmc_username, bmc_password):
                 print(f"[OK]   {name}: State={state}, Health={health}")
 
     # If more than half the PSU are failing
-    if total_psu / 2 > failing_psu:
+    if total_psu / 2 < failing_psu:
         log(
             "More than half power supplies are missing connection or are faulty which is most likely causing system issues"
         )

--- a/smci_mi325x_platform_amdgpu_alllogs_collection_with_delay_for_initial_production_bmc_firmware.py
+++ b/smci_mi325x_platform_amdgpu_alllogs_collection_with_delay_for_initial_production_bmc_firmware.py
@@ -235,7 +235,7 @@ def check_power_supplies(bmc_ip, bmc_username, bmc_password):
                 print(f"[OK]   {name}: State={state}, Health={health}")
 
     # If more than half the PSU are failing
-    if total_psu / 2 > failing_psu:
+    if total_psu / 2 < failing_psu:
         log(
             "More than half power supplies are missing connection or are faulty which is most likely causing system issues"
         )


### PR DESCRIPTION
Commit a6f2a38 introduced new power supply checking code along with a typo (ie `>` vs `<`).  Commit 18fe8d3 fixed the typo in most scripts. This commit fixes the typo in the remaining scripts.